### PR TITLE
fix packtag.tld to work with <%@ taglib uri="http://packtag.sf.net" pref...

### DIFF
--- a/packtag-core/src/main/resources/META-INF/packtag.tld
+++ b/packtag-core/src/main/resources/META-INF/packtag.tld
@@ -6,7 +6,7 @@
 	<tlib-version>3.10</tlib-version>
 	<jsp-version>1.2</jsp-version>
 	<short-name>pack</short-name>
-	<uri>https://github.com/d8bitr/packtag</uri>
+	<uri>http://packtag.sf.net</uri>
 	<display-name>JSP pack:tag Library</display-name>
 
 	<tag>


### PR DESCRIPTION
...ix="pack" %>
