### PR TITLE
Fix a bug in a tomcat 8 environment

### DIFF
--- a/packtag-core/src/main/java/net/sf/packtag/tag/PackTag.java
+++ b/packtag-core/src/main/java/net/sf/packtag/tag/PackTag.java
@@ -67,6 +67,7 @@ import net.sf.packtag.implementation.DisabledPackStrategy;
 import net.sf.packtag.strategy.PackException;
 import net.sf.packtag.strategy.PackStrategy;
 import net.sf.packtag.util.FileFetcher;
+import net.sf.packtag.util.FilenameUtils;
 import net.sf.packtag.util.HttpHeader;
 import net.sf.packtag.util.URIUtils;
 
@@ -412,13 +413,13 @@ public abstract class PackTag extends BaseTag {
 
 	/** Saves the minified resource to disk */
 	private void storeFile(final Resource resource, final String packedResource) throws IOException {
-		String cacheFilePath = getCacheFilePath() + SLASH;
-		String realPath = pageContext.getServletContext().getRealPath(SLASH) + cacheFilePath;
+		String cacheFilePath = SLASH + getCacheFilePath() + SLASH;
+		String realPath = pageContext.getServletContext().getRealPath(cacheFilePath);
 		File fileRealPath = new File(realPath);
 		if (!fileRealPath.exists()) {
 			fileRealPath.mkdirs();
 		}
-		File fileAbsolutePath = new File(realPath + determineFileName(resource));
+		File fileAbsolutePath = new File(FilenameUtils.concat(realPath, determineFileName(resource)));
 		if (fileAbsolutePath.exists()) {
 			fileAbsolutePath.delete();
 		}

--- a/packtag-core/src/main/java/net/sf/packtag/util/FilenameUtils.java
+++ b/packtag-core/src/main/java/net/sf/packtag/util/FilenameUtils.java
@@ -1,0 +1,434 @@
+package net.sf.packtag.util;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.File;
+
+/**
+ * General filename and filepath manipulation utilities.
+ * <p>
+ * When dealing with filenames you can hit problems when moving from a Windows
+ * based development machine to a Unix based production machine.
+ * This class aims to help avoid those problems.
+ * <p>
+ * <b>NOTE</b>: You may be able to avoid using this class entirely simply by
+ * using JDK {@link java.io.File File} objects and the two argument constructor
+ * {@link java.io.File#File(java.io.File, java.lang.String) File(File,String)}.
+ * <p>
+ * Most methods on this class are designed to work the same on both Unix and Windows.
+ * Those that don't include 'System', 'Unix' or 'Windows' in their name.
+ * <p>
+ * Most methods recognise both separators (forward and back), and both
+ * sets of prefixes. See the javadoc of each method for details.
+ * <p>
+ * This class defines six components within a filename
+ * (example C:\dev\project\file.txt):
+ * <ul>
+ * <li>the prefix - C:\</li>
+ * <li>the path - dev\project\</li>
+ * <li>the full path - C:\dev\project\</li>
+ * <li>the name - file.txt</li>
+ * <li>the base name - file</li>
+ * <li>the extension - txt</li>
+ * </ul>
+ * Note that this class works best if directory filenames end with a separator.
+ * If you omit the last separator, it is impossible to determine if the filename
+ * corresponds to a file or a directory. As a result, we have chosen to say
+ * it corresponds to a file.
+ * <p>
+ * This class only supports Unix and Windows style names.
+ * Prefixes are matched as follows:
+ * <pre>
+ * Windows:
+ * a\b\c.txt           --> ""          --> relative
+ * \a\b\c.txt          --> "\"         --> current drive absolute
+ * C:a\b\c.txt         --> "C:"        --> drive relative
+ * C:\a\b\c.txt        --> "C:\"       --> absolute
+ * \\server\a\b\c.txt  --> "\\server\" --> UNC
+ *
+ * Unix:
+ * a/b/c.txt           --> ""          --> relative
+ * /a/b/c.txt          --> "/"         --> absolute
+ * ~/a/b/c.txt         --> "~/"        --> current user
+ * ~                   --> "~/"        --> current user (slash added)
+ * ~user/a/b/c.txt     --> "~user/"    --> named user
+ * ~user               --> "~user/"    --> named user (slash added)
+ * </pre>
+ * Both prefix styles are matched always, irrespective of the machine that you are
+ * currently running on.
+ * <p>
+ * Origin of code: Excalibur, Alexandria, Tomcat, Commons-Utils.
+ *
+ * @version $Id: FilenameUtils.java 1307462 2012-03-30 15:13:11Z ggregory $
+ * @since 1.1
+ */
+public class FilenameUtils {
+
+    /**
+     * The Unix separator character.
+     */
+    private static final char UNIX_SEPARATOR = '/';
+
+    /**
+     * The Windows separator character.
+     */
+    private static final char WINDOWS_SEPARATOR = '\\';
+
+    /**
+     * The system separator character.
+     */
+    private static final char SYSTEM_SEPARATOR = File.separatorChar;
+
+    /**
+     * The separator character that is the opposite of the system separator.
+     */
+    private static final char OTHER_SEPARATOR;
+    static {
+        if (isSystemWindows()) {
+            OTHER_SEPARATOR = UNIX_SEPARATOR;
+        } else {
+            OTHER_SEPARATOR = WINDOWS_SEPARATOR;
+        }
+    }
+
+    /**
+     * Instances should NOT be constructed in standard programming.
+     */
+    public FilenameUtils() {
+        super();
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Determines if Windows file system is in use.
+     *
+     * @return true if the system is Windows
+     */
+    static boolean isSystemWindows() {
+        return SYSTEM_SEPARATOR == WINDOWS_SEPARATOR;
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Checks if the character is a separator.
+     *
+     * @param ch  the character to check
+     * @return true if it is a separator character
+     */
+    private static boolean isSeparator(char ch) {
+        return ch == UNIX_SEPARATOR || ch == WINDOWS_SEPARATOR;
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Normalizes a path, removing double and single dot path steps.
+     * <p>
+     * This method normalizes a path to a standard format.
+     * The input may contain separators in either Unix or Windows format.
+     * The output will contain separators in the format of the system.
+     * <p>
+     * A trailing slash will be retained.
+     * A double slash will be merged to a single slash (but UNC names are handled).
+     * A single dot path segment will be removed.
+     * A double dot will cause that path segment and the one before to be removed.
+     * If the double dot has no parent path segment to work with, {@code null}
+     * is returned.
+     * <p>
+     * The output will be the same on both Unix and Windows except
+     * for the separator character.
+     * <pre>
+     * /foo//               -->   /foo/
+     * /foo/./              -->   /foo/
+     * /foo/../bar          -->   /bar
+     * /foo/../bar/         -->   /bar/
+     * /foo/../bar/../baz   -->   /baz
+     * //foo//./bar         -->   /foo/bar
+     * /../                 -->   null
+     * ../foo               -->   null
+     * foo/bar/..           -->   foo/
+     * foo/../../bar        -->   null
+     * foo/../bar           -->   bar
+     * //server/foo/../bar  -->   //server/bar
+     * //server/../bar      -->   null
+     * C:\foo\..\bar        -->   C:\bar
+     * C:\..\bar            -->   null
+     * ~/foo/../bar/        -->   ~/bar/
+     * ~/../bar             -->   null
+     * </pre>
+     * (Note the file separator returned will be correct for Windows/Unix)
+     *
+     * @param filename  the filename to normalize, null returns null
+     * @return the normalized filename, or null if invalid
+     */
+    public static String normalize(String filename) {
+        return doNormalize(filename, SYSTEM_SEPARATOR, true);
+    }
+
+
+    /**
+     * Internal method to perform the normalization.
+     *
+     * @param filename  the filename
+     * @param separator The separator character to use
+     * @param keepSeparator  true to keep the final separator
+     * @return the normalized filename
+     */
+    private static String doNormalize(String filename, char separator, boolean keepSeparator) {
+        if (filename == null) {
+            return null;
+        }
+        int size = filename.length();
+        if (size == 0) {
+            return filename;
+        }
+        int prefix = getPrefixLength(filename);
+        if (prefix < 0) {
+            return null;
+        }
+
+        char[] array = new char[size + 2];  // +1 for possible extra slash, +2 for arraycopy
+        filename.getChars(0, filename.length(), array, 0);
+
+        // fix separators throughout
+        char otherSeparator = separator == SYSTEM_SEPARATOR ? OTHER_SEPARATOR : SYSTEM_SEPARATOR;
+        for (int i = 0; i < array.length; i++) {
+            if (array[i] == otherSeparator) {
+                array[i] = separator;
+            }
+        }
+
+        // add extra separator on the end to simplify code below
+        boolean lastIsDirectory = true;
+        if (array[size - 1] != separator) {
+            array[size++] = separator;
+            lastIsDirectory = false;
+        }
+
+        // adjoining slashes
+        for (int i = prefix + 1; i < size; i++) {
+            if (array[i] == separator && array[i - 1] == separator) {
+                System.arraycopy(array, i, array, i - 1, size - i);
+                size--;
+                i--;
+            }
+        }
+
+        // dot slash
+        for (int i = prefix + 1; i < size; i++) {
+            if (array[i] == separator && array[i - 1] == '.' &&
+                    (i == prefix + 1 || array[i - 2] == separator)) {
+                if (i == size - 1) {
+                    lastIsDirectory = true;
+                }
+                System.arraycopy(array, i + 1, array, i - 1, size - i);
+                size -=2;
+                i--;
+            }
+        }
+
+        // double dot slash
+        outer:
+        for (int i = prefix + 2; i < size; i++) {
+            if (array[i] == separator && array[i - 1] == '.' && array[i - 2] == '.' &&
+                    (i == prefix + 2 || array[i - 3] == separator)) {
+                if (i == prefix + 2) {
+                    return null;
+                }
+                if (i == size - 1) {
+                    lastIsDirectory = true;
+                }
+                int j;
+                for (j = i - 4 ; j >= prefix; j--) {
+                    if (array[j] == separator) {
+                        // remove b/../ from a/b/../c
+                        System.arraycopy(array, i + 1, array, j + 1, size - i);
+                        size -= i - j;
+                        i = j + 1;
+                        continue outer;
+                    }
+                }
+                // remove a/../ from a/../c
+                System.arraycopy(array, i + 1, array, prefix, size - i);
+                size -= i + 1 - prefix;
+                i = prefix + 1;
+            }
+        }
+
+        if (size <= 0) {  // should never be less than 0
+            return "";
+        }
+        if (size <= prefix) {  // should never be less than prefix
+            return new String(array, 0, size);
+        }
+        if (lastIsDirectory && keepSeparator) {
+            return new String(array, 0, size);  // keep trailing separator
+        }
+        return new String(array, 0, size - 1);  // lose trailing separator
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Concatenates a filename to a base path using normal command line style rules.
+     * <p>
+     * The effect is equivalent to resultant directory after changing
+     * directory to the first argument, followed by changing directory to
+     * the second argument.
+     * <p>
+     * The first argument is the base path, the second is the path to concatenate.
+     * The returned path is always normalized via {@link #normalize(String)},
+     * thus <code>..</code> is handled.
+     * <p>
+     * If <code>pathToAdd</code> is absolute (has an absolute prefix), then
+     * it will be normalized and returned.
+     * Otherwise, the paths will be joined, normalized and returned.
+     * <p>
+     * The output will be the same on both Unix and Windows except
+     * for the separator character.
+     * <pre>
+     * /foo/ + bar          -->   /foo/bar
+     * /foo + bar           -->   /foo/bar
+     * /foo + /bar          -->   /bar
+     * /foo + C:/bar        -->   C:/bar
+     * /foo + C:bar         -->   C:bar (*)
+     * /foo/a/ + ../bar     -->   foo/bar
+     * /foo/ + ../../bar    -->   null
+     * /foo/ + /bar         -->   /bar
+     * /foo/.. + /bar       -->   /bar
+     * /foo + bar/c.txt     -->   /foo/bar/c.txt
+     * /foo/c.txt + bar     -->   /foo/c.txt/bar (!)
+     * </pre>
+     * (*) Note that the Windows relative drive prefix is unreliable when
+     * used with this method.
+     * (!) Note that the first parameter must be a path. If it ends with a name, then
+     * the name will be built into the concatenated path. If this might be a problem,
+     * use getFullPath(String) on the base path argument.
+     *
+     * @param basePath  the base path to attach to, always treated as a path
+     * @param fullFilenameToAdd  the filename (or path) to attach to the base
+     * @return the concatenated path, or null if invalid
+     */
+    public static String concat(String basePath, String fullFilenameToAdd) {
+        int prefix = getPrefixLength(fullFilenameToAdd);
+        if (prefix < 0) {
+            return null;
+        }
+        if (prefix > 0) {
+            return normalize(fullFilenameToAdd);
+        }
+        if (basePath == null) {
+            return null;
+        }
+        int len = basePath.length();
+        if (len == 0) {
+            return normalize(fullFilenameToAdd);
+        }
+        char ch = basePath.charAt(len - 1);
+        if (isSeparator(ch)) {
+            return normalize(basePath + fullFilenameToAdd);
+        } else {
+            return normalize(basePath + '/' + fullFilenameToAdd);
+        }
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Returns the length of the filename prefix, such as <code>C:/</code> or <code>~/</code>.
+     * <p>
+     * This method will handle a file in either Unix or Windows format.
+     * <p>
+     * The prefix length includes the first slash in the full filename
+     * if applicable. Thus, it is possible that the length returned is greater
+     * than the length of the input string.
+     * <pre>
+     * Windows:
+     * a\b\c.txt           --> ""          --> relative
+     * \a\b\c.txt          --> "\"         --> current drive absolute
+     * C:a\b\c.txt         --> "C:"        --> drive relative
+     * C:\a\b\c.txt        --> "C:\"       --> absolute
+     * \\server\a\b\c.txt  --> "\\server\" --> UNC
+     *
+     * Unix:
+     * a/b/c.txt           --> ""          --> relative
+     * /a/b/c.txt          --> "/"         --> absolute
+     * ~/a/b/c.txt         --> "~/"        --> current user
+     * ~                   --> "~/"        --> current user (slash added)
+     * ~user/a/b/c.txt     --> "~user/"    --> named user
+     * ~user               --> "~user/"    --> named user (slash added)
+     * </pre>
+     * <p>
+     * The output will be the same irrespective of the machine that the code is running on.
+     * ie. both Unix and Windows prefixes are matched regardless.
+     *
+     * @param filename  the filename to find the prefix in, null returns -1
+     * @return the length of the prefix, -1 if invalid or null
+     */
+    public static int getPrefixLength(String filename) {
+        if (filename == null) {
+            return -1;
+        }
+        int len = filename.length();
+        if (len == 0) {
+            return 0;
+        }
+        char ch0 = filename.charAt(0);
+        if (ch0 == ':') {
+            return -1;
+        }
+        if (len == 1) {
+            if (ch0 == '~') {
+                return 2;  // return a length greater than the input
+            }
+            return isSeparator(ch0) ? 1 : 0;
+        } else {
+            if (ch0 == '~') {
+                int posUnix = filename.indexOf(UNIX_SEPARATOR, 1);
+                int posWin = filename.indexOf(WINDOWS_SEPARATOR, 1);
+                if (posUnix == -1 && posWin == -1) {
+                    return len + 1;  // return a length greater than the input
+                }
+                posUnix = posUnix == -1 ? posWin : posUnix;
+                posWin = posWin == -1 ? posUnix : posWin;
+                return Math.min(posUnix, posWin) + 1;
+            }
+            char ch1 = filename.charAt(1);
+            if (ch1 == ':') {
+                ch0 = Character.toUpperCase(ch0);
+                if (ch0 >= 'A' && ch0 <= 'Z') {
+                    if (len == 2 || !isSeparator(filename.charAt(2))) {
+                        return 2;
+                    }
+                    return 3;
+                }
+                return -1;
+
+            } else if (isSeparator(ch0) && isSeparator(ch1)) {
+                int posUnix = filename.indexOf(UNIX_SEPARATOR, 2);
+                int posWin = filename.indexOf(WINDOWS_SEPARATOR, 2);
+                if (posUnix == -1 && posWin == -1 || posUnix == 2 || posWin == 2) {
+                    return -1;
+                }
+                posUnix = posUnix == -1 ? posWin : posUnix;
+                posWin = posWin == -1 ? posUnix : posWin;
+                return Math.min(posUnix, posWin) + 1;
+            } else {
+                return isSeparator(ch0) ? 1 : 0;
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Hi,

In a tomcat 8/java 8 environment, the method PackTag.storeFile() fails because of the way the directory path is computed.

For some reason, getServletContext().getRealPath("/foo") doesn't produce a path with a trailing slash in tomcat 8, which leads to a wrong path because of the concatenation that follows.

I managed to make it work in both cases (with or without a trailing slash) by using the FilenameUtils.concat() method from commons-io. I figured you wouldn't want to add the whole library in your dependencies just for that small use case, so I copied the relevant code of apache's FilenameUtils class into the utils package.

I hope you'll find this change useful. Let me know if you want me to change something in the pull request.